### PR TITLE
Update module name to fix go install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sccmlooter
+module sccm-http-looter
 
 go 1.22
 


### PR DESCRIPTION
Installing the tool using the `go install` method fails due to the mistmatch between the respository name and the module name defined in` go.mod`.  This fixes it in my testing!